### PR TITLE
Fix includes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,4 +25,6 @@ make test
 make install
 
 # for backward compatibility
-cp -r ${PREFIX}/include/coin-or ${PREFIX}/include/coin
+install -d ${PREFIX}/include/coin
+install -m644 ${PREFIX}/include/coin-or/* ${PREFIX}/include/coin
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
 
 build:
   skip: True  # [win]
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x') }}
 
@@ -64,3 +64,4 @@ extra:
   recipe-maintainers:
     - pstjohn
     - bluescarni
+    - jschueller


### PR DESCRIPTION
Header path for backward-compatibility is wrong: headers were moved into include/coin/coin-or instead of include/coin as include/coin is already created by third parties