### PR TITLE
Fix generation of pkg-config .pc files

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -35,3 +35,5 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bluescarni @jschueller @moorepants @pstjohn
+* @bluescarni @jschueller @moorepants @pstjohn @traversaro

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/README.md
+++ b/README.md
@@ -151,4 +151,5 @@ Feedstock Maintainers
 * [@jschueller](https://github.com/jschueller/)
 * [@moorepants](https://github.com/moorepants/)
 * [@pstjohn](https://github.com/pstjohn/)
+* [@traversaro](https://github.com/traversaro/)
 

--- a/recipe/cmake/Ipopt/CMakeLists.txt
+++ b/recipe/cmake/Ipopt/CMakeLists.txt
@@ -61,7 +61,7 @@ if (COIN_ENABLE_DOWNLOAD_CLAPACK)
 endif ()
 set(PACKAGE_VERSION "${IPOPT_VERSION}")
 
-configure_file(${Ipopt_DIR}/ipopt.pc.in ${CMAKE_BINARY_DIR}/Ipopt/ipopt.pc @ONLY)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/ipopt_cmake.pc.in ${CMAKE_BINARY_DIR}/Ipopt/ipopt.pc @ONLY)
 
 set(libdir         "${Ipopt_DIR}")
 set(abs_source_dir "${CMAKE_BINARY_DIR}/bin")

--- a/recipe/cmake/Ipopt/CMakeLists.txt
+++ b/recipe/cmake/Ipopt/CMakeLists.txt
@@ -67,7 +67,7 @@ set(libdir         "${Ipopt_DIR}")
 set(abs_source_dir "${CMAKE_BINARY_DIR}/bin")
 
 install(FILES ${CMAKE_BINARY_DIR}/Ipopt/ipopt.pc
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkg-config/)
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
 
 #
 # Build

--- a/recipe/cmake/Ipopt/ipopt_cmake.pc.in
+++ b/recipe/cmake/Ipopt/ipopt_cmake.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@/coin-or
+
+Name: @PACKAGE_NAME@
+Description: Interior Point Optimizer
+URL: @PACKAGE_URL@
+Version: @PACKAGE_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lipopt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
     - {{ compiler('fortran') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - pkgconfig
 
 about:
   home: https://projects.coin-or.org/Ipopt/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,12 @@ source:
     sha256: 86354b36c691e6cd6b8049218519923ab0ce8a6f0a432c2c0de605191f2d4a1c
     patches:
       - linux-configure.patch  # [linux]
+      - pkg-config-do-not-add-requires-private.patch
 
 build:
   number: 7
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x') }}
-    -  pkg-config-do-not-add-requires-private.patch
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
       - linux-configure.patch  # [linux]
 
 build:
-  number: 6
+  number: 7
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x') }}
+    -  pkg-config-do-not-add-requires-private.patch
 
 requirements:
   build:

--- a/recipe/pkg-config-do-not-add-requires-private.patch
+++ b/recipe/pkg-config-do-not-add-requires-private.patch
@@ -1,0 +1,11 @@
+diff --git a/ipopt.pc.in b/ipopt.pc.in
+index 15a7305f..2220edd3 100644
+--- a/ipopt.pc.in
++++ b/ipopt.pc.in
+@@ -10,6 +10,5 @@ URL: @PACKAGE_URL@
+ Version: @PACKAGE_VERSION@
+ Cflags: -I${includedir}
+ @COIN_STATIC_BUILD_FALSE@Libs: -L${libdir} -lipopt
+-@COIN_STATIC_BUILD_FALSE@Requires.private: @IPOPTLIB_PCFILES@
+ @COIN_STATIC_BUILD_TRUE@Libs: -L${libdir} -lipopt @IPOPTLIB_LFLAGS_NOPC@
+ @COIN_STATIC_BUILD_TRUE@Requires: @IPOPTLIB_PCFILES@

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,10 +1,10 @@
 setlocal EnableDelayedExpansion
 
 :: Check .pc file
-pkg-config --exists --debug ipopt
+pkg-config --exists --print-errors --debug ipopt
 if errorlevel 1 exit 1
 
-pkg-config --validate --debug ipopt
+pkg-config --validate --print-errors --debug ipopt
 if errorlevel 1 exit 1
 
 cd test

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,7 +1,8 @@
 setlocal EnableDelayedExpansion
 
 :: Validate .pc file
-pkg-config --validate --debug ipopt
+pkg-config --exists --debug ipopt
+if errorlevel 1 exit 1
 
 cd test
 

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,5 +1,8 @@
 setlocal EnableDelayedExpansion
 
+:: Validate .pc file
+pkg-config --validate --debug ipopt
+
 cd test
 
 :: Compile example that links ipopt

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,6 +1,6 @@
 setlocal EnableDelayedExpansion
 
-:: Validate .pc file
+:: Check .pc file
 pkg-config --exists --debug ipopt
 if errorlevel 1 exit 1
 

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -4,6 +4,9 @@ setlocal EnableDelayedExpansion
 pkg-config --exists --debug ipopt
 if errorlevel 1 exit 1
 
+pkg-config --validate --debug ipopt
+if errorlevel 1 exit 1
+
 cd test
 
 :: Compile example that links ipopt

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-# Validate .pc file
-pkg-config --validate --debug ipopt
+# Check .pc file
+pkg-config --exists --debug ipopt
 
 # Test the ipopt binary
 ipopt mytoy.nl | grep -q "Optimal Solution"

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Validate .pc file
+pkg-config --validate --debug ipopt
+
 # Test the ipopt binary
 ipopt mytoy.nl | grep -q "Optimal Solution"
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
 # Check .pc file
-pkg-config --exists --debug ipopt
-pkg-config --validate --debug ipopt
+pkg-config --exists --print-errors --debug ipopt
+pkg-config --validate --print-errors --debug ipopt
 
 # Test the ipopt binary
 ipopt mytoy.nl | grep -q "Optimal Solution"

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,6 +2,7 @@
 
 # Check .pc file
 pkg-config --exists --debug ipopt
+pkg-config --validate --debug ipopt
 
 # Test the ipopt binary
 ipopt mytoy.nl | grep -q "Optimal Solution"


### PR DESCRIPTION
PR to fix https://github.com/conda-forge/ipopt-feedstock/issues/56 .

The validity of the .pc pkg-config files is not checked in the test scripts. 

The .pc files for *nix systems have been fixed by removing the `Requires.private` line, that in any case is not useful at all if the library is shipped just in shared form (see https://github.com/mesonbuild/meson/issues/3970).

For Windows, the template file used for generating the .pc file have been substituted with one that can be configured via CMake.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
