### PR TITLE
Re-enable Windows build 

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,110 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: win
+  pool:
+    vmImage: vs2017-win2016
+  strategy:
+    matrix:
+      win_64_:
+        CONFIG: win_64_
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables:
+    CONDA_BLD_PATH: D:\\bld\\
+
+  steps:
+    - script: |
+        choco install vcpython27 -fdv -y --debug
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Install vcpython27.msi (if needed)
+
+    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    # - script: rmdir C:\cygwin /s /q
+    #   continueOnError: true
+
+    - powershell: |
+        Set-PSDebug -Trace 1
+
+        $batchcontent = @"
+        ECHO ON
+        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
+
+        DIR "%vcpython%"
+
+        CALL "%vcpython%\vcvarsall.bat" %*
+        "@
+
+        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
+        $batchPath = "$batchDir" + "\vcvarsall.bat"
+        New-Item -Path $batchPath -ItemType "file" -Force
+
+        Set-Content -Value $batchcontent -Path $batchPath
+
+        Get-ChildItem -Path $batchDir
+
+        Get-ChildItem -Path ($batchDir + '\..')
+
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Patch vs2008 (if needed)
+
+    - task: CondaEnvironment@1
+      inputs:
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
+        installOptions: "-c conda-forge"
+        updateConda: true
+      displayName: Install conda-build and activate environment
+
+    - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
+
+    # Configure the VM
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
+
+    # Configure the VM.
+    - script: |
+        set "CI=azure"
+        call activate base
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+    
+
+    # Special cased version setting some more things!
+    - script: |
+        call activate base
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe (vs2008)
+      env:
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
+        PYTHONUNBUFFERED: 1
+      condition: contains(variables['CONFIG'], 'vs2008')
+
+    - script: |
+        call activate base
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
+      condition: not(contains(variables['CONFIG'], 'vs2008'))
+    - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
+      displayName: Validate Recipe Outputs
+
+    - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+      displayName: Upload package
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+        FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+        STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,0 +1,25 @@
+c_compiler:
+- vs2017
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2017
+fortran_compiler:
+- flang
+fortran_compiler_version:
+- '5'
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8 *netlib
+metis:
+- '5.1'
+mumps_seq:
+- '5.2'
+pin_run_as_build:
+  metis:
+    max_pin: x.x
+target_platform:
+- win-64

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ipopt-feedstock?branchName=master&jobName=osx&configuration=osx_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5618&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ipopt-feedstock?branchName=master&jobName=win&configuration=win_64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,4 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml
   - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/recipe/cmake/Ipopt/CMakeLists.txt
+++ b/recipe/cmake/Ipopt/CMakeLists.txt
@@ -912,6 +912,7 @@ set(COMMON_HDRS ${Ipopt_DIR}/src/Common/IpCachedResults.hpp
 		${Ipopt_DIR}/src/Common/IpSmartPtr.hpp
 		${Ipopt_DIR}/src/Common/IpTaggedObject.hpp
 		${Ipopt_DIR}/src/Common/IpTimedTask.hpp
+		${Ipopt_DIR}/src/Common/IpTypes.h
 		${Ipopt_DIR}/src/Common/IpTypes.hpp
 		${Ipopt_DIR}/src/Common/IpUtils.hpp)
 

--- a/recipe/cmake/Ipopt/CMakeLists.txt
+++ b/recipe/cmake/Ipopt/CMakeLists.txt
@@ -203,6 +203,7 @@ set (IPOPT_SRC_INTERFACES_LIST ${Ipopt_DIR}/src/Interfaces/IpInterfacesRegOp.cpp
                                ${Ipopt_DIR}/src/Interfaces/IpStdCInterface.cpp
                                ${Ipopt_DIR}/src/Interfaces/IpStdFInterface.c
                                ${Ipopt_DIR}/src/Interfaces/IpStdInterfaceTNLP.cpp
+			       ${Ipopt_DIR}/src/Interfaces/IpTNLP.cpp
                                ${Ipopt_DIR}/src/Interfaces/IpTNLPAdapter.cpp
                                ${Ipopt_DIR}/src/Interfaces/IpTNLPReducer.cpp)
 

--- a/recipe/cmake/Ipopt/CMakeLists.txt
+++ b/recipe/cmake/Ipopt/CMakeLists.txt
@@ -135,7 +135,8 @@ set (IPOPT_SRC_ALGORITHM_INEXACT_LIST ${Ipopt_DIR}/src/Algorithm/Inexact/IpInexa
                                       ${Ipopt_DIR}/src/Algorithm/Inexact/IpInexactPDTerminationTester.cpp
                                       ${Ipopt_DIR}/src/Algorithm/Inexact/IpIterativePardisoSolverInterface.cpp)
 
-set (IPOPT_SRC_ALGORITHM_LINEARSOLVERS_LIST ${Ipopt_DIR}/src/Algorithm/LinearSolvers/IpLinearSolversRegOp.cpp
+set (IPOPT_SRC_ALGORITHM_LINEARSOLVERS_LIST ${Ipopt_DIR}/src/Algorithm/LinearSolvers/IpLinearSolvers.c 
+                                            ${Ipopt_DIR}/src/Algorithm/LinearSolvers/IpLinearSolversRegOp.cpp
                                             ${Ipopt_DIR}/src/Algorithm/LinearSolvers/IpSlackBasedTSymScalingMethod.cpp
                                             ${Ipopt_DIR}/src/Algorithm/LinearSolvers/IpTripletToCSRConverter.cpp
                                             ${Ipopt_DIR}/src/Algorithm/LinearSolvers/IpTSymDependencyDetector.cpp
@@ -188,15 +189,8 @@ set (IPOPT_SRC_CONTRIB_CGPENALTY_LIST ${Ipopt_DIR}/src/contrib/CGPenalty/IpCGPen
                                       ${Ipopt_DIR}/src/contrib/CGPenalty/IpCGSearchDirCalc.cpp
                                       ${Ipopt_DIR}/src/contrib/CGPenalty/IpPiecewisePenalty.cpp)
 
-set (IPOPT_SRC_CONTRIB_LINEARSOLVERLOADER_LIST ${Ipopt_DIR}/src/contrib/LinearSolverLoader/LibraryHandler.c
-                                               ${Ipopt_DIR}/src/contrib/LinearSolverLoader/HSLLoader.c)
-
-if (IPOPT_ENABLE_LINEARSOLVERLOADER)
-  set(IPOPT_SRC_CONTRIB_LINEARSOLVERLOADER_LIST ${IPOPT_SRC_CONTRIB_LINEARSOLVERLOADER_LIST}
-                                                ${Ipopt_DIR}/src/contrib/LinearSolverLoader/PardisoLoader.c)
-endif ()
-
-set (IPOPT_SRC_COMMON_LIST ${Ipopt_DIR}/src/Common/IpJournalist.cpp
+set (IPOPT_SRC_COMMON_LIST ${Ipopt_DIR}/src/Common/IpLibraryLoader.cpp 
+                           ${Ipopt_DIR}/src/Common/IpJournalist.cpp
                            ${Ipopt_DIR}/src/Common/IpObserver.cpp
                            ${Ipopt_DIR}/src/Common/IpOptionsList.cpp
                            ${Ipopt_DIR}/src/Common/IpRegOptions.cpp
@@ -245,7 +239,6 @@ set (IPOPT_SRC_LIST ${IPOPT_SRC_ALGORITHM_LIST}
                     ${IPOPT_SRC_APPS_CUTERINTERFACE_LIST}
                     ${IPOPT_SRC_APPS_AMPLSOLVER_LIST}
                     ${IPOPT_SRC_CONTRIB_CGPENALTY_LIST}
-                    ${IPOPT_SRC_CONTRIB_LINEARSOLVERLOADER_LIST}
                     ${IPOPT_SRC_COMMON_LIST}
                     ${IPOPT_SRC_INTERFACES_LIST}
                     ${IPOPT_SRC_LINALG_LIST}
@@ -910,6 +903,7 @@ set(COMMON_HDRS ${Ipopt_DIR}/src/Common/IpCachedResults.hpp
 	        ${Ipopt_DIR}/src/Common/IpDebug.hpp
 		${Ipopt_DIR}/src/Common/IpException.hpp
 		${Ipopt_DIR}/src/Common/IpJournalist.hpp
+		${Ipopt_DIR}/src/Common/IpLibraryLoader.hpp
 		${Ipopt_DIR}/src/Common/IpObserver.hpp
 		${Ipopt_DIR}/src/Common/IpOptionsList.hpp
 		${Ipopt_DIR}/src/Common/IpReferenced.hpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - pkg-config-do-not-add-requires-private.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - pkg-config-do-not-add-requires-private.patch
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x') }}
 


### PR DESCRIPTION
The PR updates the CMake-based buildsystem by adding and removing the files that changed from Ipopt 3.13 to 3.14 .
Fix https://github.com/conda-forge/ipopt-feedstock/issues/64 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

