### PR TITLE
Cleanup trailine empty lines in build.sh

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,5 +30,3 @@ make install
 # for backward compatibility
 install -d ${PREFIX}/include/coin
 install -m644 ${PREFIX}/include/coin-or/* ${PREFIX}/include/coin
-
-


### PR DESCRIPTION
Minor cleanup, but mainly used to re-trigger CI and solve https://github.com/conda-forge/ipopt-feedstock/issues/80 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
