### PR TITLE
 Add spral linear solver on Linux 

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -23,11 +23,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -60,7 +60,10 @@ jobs:
         if EXIST LICENSE.txt (
           copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
         )
-        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables
+        if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+          set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+        )
+        conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
       displayName: Build recipe
       env:
         PYTHONUNBUFFERED: 1

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '11'
+- '12'
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/recipe/677.patch
+++ b/recipe/677.patch
@@ -1,0 +1,60 @@
+From c9a035aeb8914f331aa809a44365670ef63d80d4 Mon Sep 17 00:00:00 2001
+From: Alexis Montoison <alexis.montoison@polymtl.ca>
+Date: Tue, 6 Jun 2023 23:48:25 -0400
+Subject: [PATCH 1/2] Linear solvers such as MUMPS should prefered over SPRAL
+
+---
+ src/Algorithm/IpAlgBuilder.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/Algorithm/IpAlgBuilder.cpp b/src/Algorithm/IpAlgBuilder.cpp
+index 8c622c17f..83d66cd50 100644
+--- a/src/Algorithm/IpAlgBuilder.cpp
++++ b/src/Algorithm/IpAlgBuilder.cpp
+@@ -225,10 +225,6 @@ void AlgorithmBuilder::RegisterOptions(
+    {
+       defaultsolver = "pardiso";
+    }
+-   else if( availablesolverslinked & IPOPTLINEARSOLVER_SPRAL )
+-   {
+-      defaultsolver = "spral";
+-   }
+    else if( availablesolverslinked & IPOPTLINEARSOLVER_WSMP )
+    {
+       defaultsolver = "wsmp";
+@@ -241,6 +237,10 @@ void AlgorithmBuilder::RegisterOptions(
+    {
+       defaultsolver = "pardisomkl";
+    }
++   else if( availablesolverslinked & IPOPTLINEARSOLVER_SPRAL )
++   {
++      defaultsolver = "spral";
++   }
+    else if( availablesolverslinked & IPOPTLINEARSOLVER_MA77 )
+    {
+       defaultsolver = "ma77";
+
+From cd54547ae62a404eea80d9fa6ec6ddef5c805ad1 Mon Sep 17 00:00:00 2001
+From: Stefan Vigerske <svigerske@users.noreply.github.com>
+Date: Wed, 7 Jun 2023 09:27:32 +0200
+Subject: [PATCH 2/2] add changelog entry
+
+---
+ ChangeLog.md | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/ChangeLog.md b/ChangeLog.md
+index b834829c7..c82bde275 100644
+--- a/ChangeLog.md
++++ b/ChangeLog.md
+@@ -7,6 +7,10 @@ More detailed information about incremental changes can be found in the
+ 
+ ## 3.14
+ 
++### 3.14.13 (2023-xx-yy)
++
++- Reduced priority for making Spral the default value for option linear_solver [#677].
++
+ ### 3.14.12 (2023-04-05)
+ 
+ - Fix that a source file was installed and install more header files.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,7 +23,7 @@ cd build
   --with-asl \
   --with-asl-cflags="-I${PREFIX}/include/asl" \
   --with-asl-lflags="-lasl" \
-  --prefix=${PREFIX}
+  --prefix=${PREFIX} || cat config.log
 
 make -j${CPU_COUNT}
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib"
 export SPRAL_OPTIONS=
 if [ "$(uname)" == "Linux" ]; then
   export LDFLAGS="${LDFLAGS} -lrt"
-  export SPRAL_OPTIONS="--with-spral --with-spral-cflags=\"-I${PREFIX}/include\" --with-spral-lflags=\"-lspral\""
+  export SPRAL_OPTIONS="--with-spral --with-spral-cflags=-I${PREFIX}/include --with-spral-lflags=-lspral"
 fi
 
 mkdir build

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,22 +5,21 @@ cp $BUILD_PREFIX/share/gnuconfig/config.* .
 cd $SRC_DIR
 
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib"
+export SPRAL_OPTIONS=
 if [ "$(uname)" == "Linux" ]; then
   export LDFLAGS="${LDFLAGS} -lrt"
+  export SPRAL_OPTIONS="--with-spral --with-spral-cflags=\"-I${PREFIX}/include\" --with-spral-lflags=\"-lspral\""
 fi
 
 mkdir build
 cd build
 
 ../configure \
-  --without-hsl \
+  --without-hsl $SPRAL_OPTIONS \
   --disable-java \
   --with-mumps \
   --with-mumps-cflags="-I${PREFIX}/include/mumps_seq" \
   --with-mumps-lflags="-ldmumps_seq -lmumps_common_seq -lpord_seq -lmpiseq_seq -lesmumps -lscotch -lscotcherr -lmetis -lgfortran" \
-  --with-spral \
-  --with-spral-cflags="-I${PREFIX}/include" \
-  --with-spral-lflags="-lspral" \
   --with-asl \
   --with-asl-cflags="-I${PREFIX}/include/asl" \
   --with-asl-lflags="-lasl" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,9 @@ cd build
   --with-mumps \
   --with-mumps-cflags="-I${PREFIX}/include/mumps_seq" \
   --with-mumps-lflags="-ldmumps_seq -lmumps_common_seq -lpord_seq -lmpiseq_seq -lesmumps -lscotch -lscotcherr -lmetis -lgfortran" \
+  --with-spral \
+  --with-spral-cflags="-I${PREFIX}/include" \
+  --with-spral-lflags="-lspral" \
   --with-asl \
   --with-asl-cflags="-I${PREFIX}/include/asl" \
   --with-asl-lflags="-lasl" \
@@ -25,6 +28,10 @@ cd build
 
 make -j${CPU_COUNT}
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
+  # Environment variables needed by spral
+  # See https://github.com/ralna/spral#usage-at-a-glance
+  export OMP_CANCELLATION=TRUE
+  export OMP_PROC_BIND=TRUE
   make test
 fi
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
     sha256: 6b06cd6280d5ca52fc97ca95adaaddd43529e6e8637c274e21ee1072c3b4577f
     patches:
       - pkg-config-do-not-add-requires-private.patch
+      - 677.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x.x') }}
 
@@ -31,6 +32,7 @@ requirements:
     - liblapack
     - metis
     - mumps-seq
+    - libspral  # [linux]
     - ampl-mp  # [not win]
 
 test:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -17,5 +17,5 @@ if errorlevel 1 exit 1
 set PATH=C:\Windows\System32;%PATH%
 
 :: Run example
-.\cpp_example.exe | find "Optimal Solution"
+.\cpp_example.exe mumps | find "Optimal Solution"
 if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -21,4 +21,11 @@ else
   ${CXX} -L$PREFIX/lib -lipopt -I$PREFIX/include/coin-or -o cpp_example cpp_example.o MyNLP.o
 fi
 
-./cpp_example | grep -q "Optimal Solution"
+./cpp_example mumps | grep -q "Optimal Solution"
+if [ $(uname -s) == 'Linux' ]; then
+  echo "Test spral linear solver"
+  # Environment variables needed by spral
+  export OMP_CANCELLATION=TRUE
+  export OMP_PROC_BIND=TRUE
+  ./cpp_example spral | grep -q "Optimal Solution"
+fi

--- a/recipe/test/cpp_example.cpp
+++ b/recipe/test/cpp_example.cpp
@@ -16,14 +16,22 @@
 
 using namespace Ipopt;
 
-int main(int argv, char* argc[])
+int main(int argc, char* argv[])
 {
   // Regression test for https://github.com/conda-forge/ipopt-feedstock/issues/57
   if (!Ipopt::IsFiniteNumber(0.0)) {
     std::cout << std::endl << std::endl << "*** Error detected in Ipopt::IsFiniteNumber!" << std::endl;
     return 1;
   }
-  
+
+  if (argc < 2) {
+    std::cerr << std::endl << std::endl << "*** Missing linear_solver in command line" << std::endl;
+    return EXIT_FAILURE;
+  }
+  else {
+    std::cout << "*** Running example with linear solver " << argv[1] << std::endl;
+  }
+
   // Create an instance of your nlp...
   SmartPtr<TNLP> mynlp = new MyNLP();
 
@@ -33,6 +41,7 @@ int main(int argv, char* argc[])
   // example with an Ipopt Windows DLL
   SmartPtr<IpoptApplication> app = IpoptApplicationFactory();
   app->Options()->SetNumericValue("tol", 1e-9);
+  app->Options()->SetStringValue("linear_solver", argv[1]);
 
   // Initialize the IpoptApplication and process the options
   ApplicationReturnStatus status;


### PR DESCRIPTION
This PR enables support for the spral linear solver (see https://coin-or.github.io/Ipopt/INSTALL.html#DOWNLOAD_SPRAL) on Linux, as for now spral on conda-forge is available just on Linux.

Beside modifications to enable the compilation and the tests, this PR also backports https://github.com/coin-or/Ipopt/pull/677 to the feedstock, to ensure that mumps remain the default linear solver, has anyhow that will be the case in the next release of ipopt.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
