### PR TITLE
Add back scotch and metis dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -26,6 +26,10 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -30,6 +30,10 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -26,6 +26,10 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -26,8 +26,12 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+libscotch:
+- 7.0.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
+metis:
+- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -26,8 +26,12 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+libscotch:
+- 7.0.4
 macos_machine:
 - arm64-apple-darwin20.0.0
+metis:
+- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -16,6 +16,10 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
+libscotch:
+- 7.0.4
+metis:
+- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,7 +19,7 @@ cd build
   --disable-java \
   --with-mumps \
   --with-mumps-cflags="-I${PREFIX}/include/mumps_seq" \
-  --with-mumps-lflags="$(pkg-config --libs dmumps_seq)" \
+  --with-mumps-lflags="-ldmumps_seq -lmumps_common_seq -lpord_seq -lmpiseq_seq -lesmumps -lscotch -lscotcherr -lmetis -lgfortran" \
   --with-asl \
   --with-asl-cflags="-I${PREFIX}/include/asl" \
   --with-asl-lflags="-lasl" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
       - pkg-config-do-not-add-requires-private.patch
 
 build:
-  number: 7
+  number: 8
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x.x') }}
 
@@ -31,6 +31,8 @@ requirements:
     - libblas
     - liblapack
     - mumps-seq
+    - metis
+    - libscotch
     - libspral  # [linux]
     - ampl-mp  # [not win]
 


### PR DESCRIPTION
Revert https://github.com/conda-forge/ipopt-feedstock/pull/112 as a workaround for https://github.com/conda-forge/ipopt-feedstock/issues/114 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
