### PR TITLE
remove libscotch, metis dependencies (again)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,7 +19,7 @@ cd build
   --disable-java \
   --with-mumps \
   --with-mumps-cflags="-I${PREFIX}/include/mumps_seq" \
-  --with-mumps-lflags="-ldmumps_seq -lmumps_common_seq -lpord_seq -lmpiseq_seq -lesmumps -lscotch -lscotcherr -lmetis -lgfortran" \
+  --with-mumps-lflags="$(pkg-config --libs dmumps_seq)" \
   --with-asl \
   --with-asl-cflags="-I${PREFIX}/include/asl" \
   --with-asl-lflags="-lasl" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
       - pkg-config-do-not-add-requires-private.patch
 
 build:
-  number: 9
+  number: 10
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x.x') }}
 
@@ -31,8 +31,6 @@ requirements:
     - libblas
     - liblapack
     - mumps-seq
-    - metis
-    - libscotch
     - libspral  # [linux]
     - ampl-mp  # [not win]
 


### PR DESCRIPTION
reissue #112 now that we have scotch 7.0.5 fixed by https://github.com/conda-forge/scotch-feedstock/pull/92

closes #114