### PR TITLE
Switch to use ampl-asl instead of ampl-mp

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,15 +11,15 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-12
+    vmImage: macOS-13
   strategy:
     matrix:
       osx_64_:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -24,6 +24,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,31 +14,16 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    MINIFORGE_HOME: D:\Miniforge
     UPLOAD_TEMP: D:\\tmp
 
   steps:
-
-    - task: PythonScript@0
-      displayName: 'Download Miniforge'
-      inputs:
-        scriptSource: inline
-        script: |
-          import urllib.request
-          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe'
-          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
-          urllib.request.urlretrieve(url, path)
-
-    - script: |
-        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
-      displayName: Install Miniforge
-
-    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
-      displayName: Add conda to PATH
 
     - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
+        MINIFORGE_HOME: $(MINIFORGE_HOME)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -26,10 +26,6 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-libscotch:
-- 7.0.4
-metis:
-- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:
@@ -38,5 +34,3 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+ipopt:
+- 3.14.16
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ c_stdlib_version:
 cdt_arch:
 - aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -30,10 +30,6 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-libscotch:
-- 7.0.4
-metis:
-- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:
@@ -42,5 +38,3 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -26,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+ipopt:
+- 3.14.16
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -7,7 +7,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -26,10 +26,6 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-libscotch:
-- 7.0.4
-metis:
-- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:
@@ -38,5 +34,3 @@ zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
-- - c_stdlib_version
-  - cdt_name

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+ipopt:
+- 3.14.16
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -26,12 +26,8 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-libscotch:
-- 7.0.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
-metis:
-- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+ipopt:
+- 3.14.16
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -26,12 +26,8 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-libscotch:
-- 7.0.4
 macos_machine:
 - arm64-apple-darwin20.0.0
-metis:
-- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -22,6 +22,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '13'
+ipopt:
+- 3.14.16
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -16,10 +16,6 @@ libblas:
 - 3.9 *netlib
 liblapack:
 - 3.9 *netlib
-libscotch:
-- 7.0.4
-metis:
-- 5.1.0
 mumps_seq:
 - 5.7.3
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - flang
 fortran_compiler_version:
 - '5'
+ipopt:
+- 3.14.16
 libblas:
 - 3.9 *netlib
 liblapack:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,12 +31,12 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
+mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
+echo > /opt/conda/conda-meta/history
+micromamba install --root-prefix ~/.conda --prefix /opt/conda \
+    --yes --override-channels --channel conda-forge --strict-channel-priority \
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
-
-mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -76,8 +76,8 @@ else
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
-    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
-    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir "${RECIPE_ROOT}" -m "${CONFIG_FILE}" || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
 
     ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -7,28 +7,39 @@ source .scripts/logging_utils.sh
 set -xe
 
 MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
+MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
 
-( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
-
-MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
-curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
-rm -rf ${MINIFORGE_HOME}
-bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
-
-( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
+MICROMAMBA_VERSION="1.5.10-0"
+if [[ "$(uname -m)" == "arm64" ]]; then
+  osx_arch="osx-arm64"
+else
+  osx_arch="osx-64"
+fi
+MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
+MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
+echo "Downloading micromamba ${MICROMAMBA_VERSION}"
+micromamba_exe="$(mktemp -d)/micromamba"
+curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
+chmod +x "${micromamba_exe}"
+echo "Creating environment"
+"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
+  --channel conda-forge \
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
+mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
+echo "Cleaning up micromamba"
+rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
+( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-
-source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
+echo "Activating environment"
+source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
 conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
-mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+
 
 
 
@@ -88,8 +99,8 @@ else
 
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
-    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
-    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir ./recipe -m ./.ci_support/${CONFIG}.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
 
     ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -3,29 +3,49 @@
 :: changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 :: benefit from the improvement.
 
-:: Note: we assume a Miniforge installation is available
-
 :: INPUTS (required environment variables)
 :: CONFIG: name of the .ci_support/*.yaml file for this job
 :: CI: azure, github_actions, or unset
+:: MINIFORGE_HOME: where to install the base conda environment
 :: UPLOAD_PACKAGES: true or false
 :: UPLOAD_ON_BRANCH: true or false
 
 setlocal enableextensions enabledelayedexpansion
 
+FOR %%A IN ("%~dp0.") DO SET "REPO_ROOT=%%~dpA"
+if "%MINIFORGE_HOME%"=="" set "MINIFORGE_HOME=%USERPROFILE%\Miniforge3"
+:: Remove trailing backslash, if present
+if "%MINIFORGE_HOME:~-1%"=="\" set "MINIFORGE_HOME=%MINIFORGE_HOME:~0,-1%"
+call :start_group "Provisioning base env with micromamba"
+set "MAMBA_ROOT_PREFIX=%MINIFORGE_HOME%-micromamba-%RANDOM%"
+set "MICROMAMBA_VERSION=1.5.10-0"
+set "MICROMAMBA_URL=https://github.com/mamba-org/micromamba-releases/releases/download/%MICROMAMBA_VERSION%/micromamba-win-64"
+set "MICROMAMBA_TMPDIR=%TMP%\micromamba-%RANDOM%"
+set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
+
+echo Downloading micromamba %MICROMAMBA_VERSION%
+if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
+certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+
+echo Creating environment
+call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
+    --channel conda-forge ^
+    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+if !errorlevel! neq 0 exit /b !errorlevel!
+echo Removing %MAMBA_ROOT_PREFIX%
+del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
+del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+
 call :start_group "Configuring conda"
 
 :: Activate the base conda environment
-call activate base
+echo Activating environment
+call "%MINIFORGE_HOME%\Scripts\activate.bat"
 :: Configure the solver
 set "CONDA_SOLVER=libmamba"
 if !errorlevel! neq 0 exit /b !errorlevel!
 set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
-
-:: Provision the necessary dependencies to build the recipe later
-echo Installing dependencies
-mamba.exe install pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
-if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
 echo Setting up configuration
@@ -59,8 +79,8 @@ conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTR
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 call :start_group "Inspecting artifacts"
-:: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
-WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+:: inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+WHERE inspect_artifacts >nul 2>nul && inspect_artifacts --recipe-dir ".\recipe" -m .ci_support\%CONFIG%.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
 call :end_group
 
 :: Prepare some environment variables for the upload step

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,32 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
-jobs:
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml
-  - template: ./.azure-pipelines/azure-pipelines-win.yml
+stages:
+- stage: Check
+  jobs:
+    - job: Skip
+      pool:
+        vmImage: 'ubuntu-22.04'
+      variables:
+        DECODE_PERCENTS: 'false'
+        RET: 'true'
+      steps:
+      - checkout: self
+        fetchDepth: '2'
+      - bash: |
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
+          echo "##vso[task.setvariable variable=log]$git_log"
+        displayName: Obtain commit message
+      - bash: echo "##vso[task.setvariable variable=RET]false"
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
+        displayName: Skip build?
+      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+        name: result
+        displayName: Export result
+- stage: Build
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
+  jobs:
+    - template: ./.azure-pipelines/azure-pipelines-linux.yml
+    - template: ./.azure-pipelines/azure-pipelines-osx.yml
+    - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
       - pkg-config-do-not-add-requires-private.patch
 
 build:
-  number: 10
+  number: 11
   run_exports:
     - {{ pin_subpackage('ipopt', max_pin='x.x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - liblapack
     - mumps-seq
     - libspral  # [linux]
-    - ampl-mp  # [not win]
+    - ampl-asl  # [not win]
 
 test:
   files:


### PR DESCRIPTION
See https://github.com/conda-forge/staged-recipes/pull/28198#issue-2655999717 . This is the first step in solving https://github.com/conda-forge/ipopt-feedstock/issues/55 . I wanted to enable the support for it on Windows, but then I noticed that the vendored CMake build system that we are using does not have proper support for it. Probably the proper solution is to switch to use the upstream autotools-based build system also on Windows, but anyhow I do no think we need to wait to switch to ampl-asl .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
